### PR TITLE
Polishing the spec draft a bit adding links etc (#87)

### DIFF
--- a/docs/json_data_template/master.adoc
+++ b/docs/json_data_template/master.adoc
@@ -43,17 +43,16 @@ include::master00-amendment_record.adoc[leveloffset=+1]
 
 === Primary Author
 
-* xxxx
+* Thomas Beale, Ars Semantica (UK); openEHR Foundation Management Board.
 
 === Contributors
 
-This specification has benefited from formal and informal input from the openEHR and wider health informatics community. The openEHR Foundation would like to recognise the following people for their contributions.
+This specification has benefited from formal and informal input from the openEHR and wider health informatics community. The openEHR Foundation would like to recognise the following  for their contributions.
 
-* xxxx
+A significant part of the design ideas and content of this specification was adapted from
 
-=== Support
-
-A significant part of the content of this specification was adapted from the Marand 'Web Templates' specification, kindly provided by Marand d.o.o. (Slovenia).
+* the Marand 'Web Templates' specification, kindly provided by Better by Marand d.o.o. (Slovenia), and 
+* the EtherCIS ECISFLAT format by the EtherCIS community, see https://github.com/ethercis/ethercis/blob/master/doc/flat%20json.md
 
 === Trademarks
 

--- a/docs/json_data_template/master01-preface.adoc
+++ b/docs/json_data_template/master01-preface.adoc
@@ -6,7 +6,7 @@ This document describes a 'simplified template' (ST) format, along with various 
 
 == Status
 
-This specification is in the {spec_status} state. The development version of this document can be found at {openehr_json_commit_formats}[{openehr_json_commit_formats}^].
+This specification is in the {spec_status} state. The development version of this document can be found at {json_data_template}[{json_data_template}^].
 
 Known omissions or questions are indicated in the text with a 'to be determined' paragraph, as follows:
 [.tbd]
@@ -22,8 +22,7 @@ To see changes made due to previously reported issues, see the {component_histor
 
 == Conformance
 
-xxx
+When used with openEHR-REST API, the available calls to be conformance tested are the same as for other openEHR serialisation formats (canonical JSON etc), but with at different representation format (indicated by setting appropriate Content-Type http header).
 
-== Tooling
-
-xxx
+[.tbd]
+*TBD*: Conformance testing and Content-Type will be further described later. 

--- a/docs/json_data_template/master02-overview.adoc
+++ b/docs/json_data_template/master02-overview.adoc
@@ -23,10 +23,10 @@ The starting point for defining a developer-friendly commit format is therefore 
 
 Template-specificity provides a route for defining and generating a serial format such that _each openEHR template_ can be used to define one or more reasonably simple commit formats. Two such formats are discussed here:
 
-* _near-canonical RM JSON data template (ncJDT)_, originally devised for the EtherCIS project;
-* _simplified IM JSON data template (sJDT)_, based on the 'web template' format originally created by Marand for the Better platform.
+* _near-canonical RM JSON data template (ncJDT)_, originally devised for the EtherCIS project, see https://github.com/ethercis/ethercis/blob/master/doc/flat%20json.md
+* _simplified IM JSON data template (sJDT)_, based on the 'web template' format originally created by Marand for the Better platform, see https://www.ehrscape.com/examples.html
 
-The first of these is an extract from an Operational Template (OPT) that uses AQL-style paths, and apart from simplification of the `DV_XXX` and `PARTY_PROXY` types, retains the openEHR RM structure. An example is shown below.
+The first of these (ncJDT) is an extract from an Operational Template (OPT) that uses AQL-style paths (based on natural language independent codes like `at0001`), and apart from simplification of the `DV_XXX` and `PARTY_PROXY` types, retains the openEHR RM structure. An example is shown below.
 
 [source, json]
 --------
@@ -55,7 +55,7 @@ The first of these is an extract from an Operational Template (OPT) that uses AQ
 }
 --------
 
-The latter is based on a more radical simplification of the openEHR RM and BASE models, as well as a more programmer-friendly rendering of paths. Under the latter approach, a lab result data structure could be represented using non-canonical attribute or tag names such as 'serum_sodium', 'serum_potassium', etc (or in any other natural language, including script-based languages), instead of each node appearing under the canonical `CLUSTER._items_` attribute. An example is shown below.
+The latter (sJDT) is based on a more radical simplification of the openEHR RM and BASE models, as well as a more programmer-friendly (atural language based) rendering of paths. Under this approach, a lab result data structure could be represented using non-canonical, attribute or tag names such as 'serum_sodium', 'serum_potassium', etc (in English or in any other natural language, including script-based languages), instead of each node appearing under the canonical `CLUSTER._items_` attribute and codes like `at0001`. An example is shown below.
 
 [source, json]
 --------
@@ -89,11 +89,13 @@ The latter is based on a more radical simplification of the openEHR RM and BASE 
 }
 --------
 
+*A developer just using the sJDT or ncJDT as illustrated above in a specific example-based use case does not necessarily need to understand the detailed steps of conversions described below.* Platforms based on openEHR can have services that generate example instances based on openeEHR templates to make work easier for such developers. The detailed descriptions below are primarily intended for developers creating and maintaining underlying openEHR platforms or dealing with complex use cases.
+
 To make any form of 'simplified format' work, the following requirements must be met:
 
 * the format makes it possible to _abstract away rigorous structural complexity_ of the canonical model where possible, mainly by making the data less self-standing, and relying more on a schema;
 * the format definition for any given commit data can be completely and routinely _machine generated_ from its canonical definition, i.e. from an openEHR OPT, or other upstream canonical definition;
-* data instances of the simplified format definition can be _routinely converted to canonical format_ at execution time.
+* data instances of the simplified format definition can be _routinely machine converted to canonical format_ at execution time.
 
 A generic high-level algorithm for creating both kinds of data template definition from an Operational Template (OPT) is illustrated below.
 
@@ -101,7 +103,7 @@ A generic high-level algorithm for creating both kinds of data template definiti
 .Scheme for generation of JSON Template definitions
 image::{diagrams_uri}/simplified_template_definition.svg[id=simplified_template_definition, align="center"]
 
-In the above, both the near-canonical data and simplified data template definitions are created via a series of transformations starting with an OPT, followed by RM flattening, and then two stages of JSON format generation. The more heavily simplified form is created via an extra step, in which an original OPT is converted by the `sOPT transformer` to a _simplified OPT (sOPT)_, which is a regular-structured OPT, but whose underlying reference model is a Simplified Information Model (SIM), based on the canonical Reference Model (RM) and related openEHR Information Models (Base, etc).
+In the above, both the near-canonical data and simplified data template definitions are created via a series of transformations starting with an OPT, followed by RM flattening, and then two stages of JSON format generation. The more heavily simplified form is created via an extra step, in which an original OPT is converted by the `sOPT transformer` to a _simplified OPT (sOPT)_, which is a regular-structured OPT, but whose underlying reference model is a _Simplified Information Model (SIM)_, based on the canonical Reference Model (RM) and related openEHR Information Models (Base, etc).
 
 TODO: in fact, even the near-canonical data template has to be generated via a minimal sOPT step.
 


### PR DESCRIPTION
* Updating acknowledgements

* hypertext-linking problem workaround

* Changed link due to document name change

* Updated conformance section and deleted tooling section (until we know why we want it)

* Expanded and clarified text

* fixed link typo

* layout fix

* typo fix